### PR TITLE
Discard any tags with no value, updated readme to give some development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # kairosdb-streamer
-Takes messages from stdin and uploads them to kairosdb. This is designed to work with the fluentd exec plugin. 
+Takes messages from stdin and uploads them to kairosdb. This is designed to work with the fluentd exec plugin.
 
 # Installation
 ```bash
 go get github.com/swco/kairosdb-streamer
 go install github.com/swco/kairosdb-streamer
 ```
+
+# Development
+To simulate a kairosdb instance in development you can use socat:
+
+    socat TCP-LISTEN:4242,fork -
+
+metrics are expected to be read from a file in the following format:
+
+    {"timestamp":1427291847309,"name":"memcache.status.connections","value":427.0,"tags":{"function":"cache","datacenter":"DC1","host":"host1.com","serverid":"HOST1"}}
+    {"timestamp":1427291847309,"name":"memcache.status.connections","value":200.0,"tags":{"function":"cache","datacenter":"DC2","host":"host2.com","serverid":"HOST2"}}
+    

--- a/main.go
+++ b/main.go
@@ -59,7 +59,10 @@ func main() {
 		o := fmt.Sprintf("put %s %d %f", m.Name, m.Timestamp, m.Value)
 
 		for name, value := range m.Tags {
-			o += fmt.Sprintf(" %s=%s", name, value)
+			//empty tags will generate an error on ingest
+			if value != "" {
+				o += fmt.Sprintf(" %s=%s", name, value)
+			}
 		}
 
 		o += "\n"


### PR DESCRIPTION
Resolves the following kairosdb error:

03-25|14:11:28.365 [New I/O worker #10] WARN  [TelnetServer.java:122] - Failed to execute command: put ...[snip]...  Reason: tag[4] must be in the format 'name=value'
