### PR TITLE
Fixes skipping invalid metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,18 +64,16 @@ func main() {
 			continue
 		}
 
-		o := fmt.Sprintf("put %s %d %f", m.Name, m.Timestamp, m.Value)
+		fmt.Fprintf(conn, "put %s %d %f", m.Name, m.Timestamp, m.Value)
 
 		for name, value := range m.Tags {
 			//empty tags will generate an error on ingest
 			if value != "" {
-				o += fmt.Sprintf(" %s=%s", name, value)
+				fmt.Fprintf(conn, " %s=%s", name, value)
 			}
 		}
 
-		o += "\n"
-
-		fmt.Fprint(conn, o)
+		fmt.Fprint(conn, "\n")
 	}
 
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Changes the code to read and decode the input line by line rather then with a stream. json.Decoder does not seem to skip invalid json and so gets stuck in an infinite loop if you just try to continue.

Also changed the errors to be printed to stderr rather then stdout as good practise.
